### PR TITLE
Update to BookAppointmentDto: No longer contains service type ID

### DIFF
--- a/BE/SkincareBookingSystem.Models/Dto/Booking/Appointment/BookAppointmentDto.cs
+++ b/BE/SkincareBookingSystem.Models/Dto/Booking/Appointment/BookAppointmentDto.cs
@@ -9,7 +9,6 @@ namespace SkincareBookingSystem.Models.Dto.Booking.Appointment
     public class BookAppointmentDto
     {
         public Guid TherapistId { get; set; } = Guid.Empty;
-        public Guid ServiceTypeId { get; set; }
         public Guid SlotId { get; set; } = Guid.Empty;
         public Guid? CustomerId { get; set; } = null!;
         public DateOnly AppointmentDate { get; set; }


### PR DESCRIPTION
(which is previously used to handle auto-assignment, but now has been moved to AutoAssignmentDto)